### PR TITLE
Changes in vocabs serializers to allow assigning a user who creates an instance

### DIFF
--- a/vocabs/serializers.py
+++ b/vocabs/serializers.py
@@ -1,41 +1,30 @@
 from rest_framework import serializers
 from .models import *
+from django.contrib.auth.models import User
 
 
-class SkosConceptSchemeSerializer(serializers.HyperlinkedModelSerializer):
+class SkosConceptSchemeSerializer(serializers.ModelSerializer):
     has_concepts = serializers.HyperlinkedRelatedField(many=True, read_only=True, view_name='skosconcept-detail')
-    created_by = serializers.CharField(read_only=True)
-    curator = serializers.StringRelatedField(many=True)
+    curator = serializers.StringRelatedField(many=True, required=False)
+    created_by = serializers.SlugRelatedField(queryset=User.objects.all(), slug_field='username')
 
     class Meta:
         model = SkosConceptScheme
         fields = '__all__'
 
 
-class SkosCollectionSerializer(serializers.HyperlinkedModelSerializer):
+class SkosCollectionSerializer(serializers.ModelSerializer):
     has_members = serializers.HyperlinkedRelatedField(many=True, read_only=True, view_name='skosconcept-detail')
-    created_by = serializers.CharField(read_only=True)
+    created_by = serializers.SlugRelatedField(queryset=User.objects.all(), slug_field='username')
 
     class Meta:
         model = SkosCollection
         fields = '__all__'
 
 
-class SkosConceptSerializer(serializers.HyperlinkedModelSerializer):
-    created_by = serializers.CharField(read_only=True)
+class SkosConceptSerializer(serializers.ModelSerializer):
+    created_by = serializers.SlugRelatedField(queryset=User.objects.all(), slug_field='username')
 
     class Meta:
         model = SkosConcept
-        fields = (
-            'id', 'url',
-            'pref_label', 'pref_label_lang',
-            'scheme', 'collection',
-            'broader_concept', 'narrower_concepts',
-            'notation', 'related',
-            'broad_match', 'narrow_match',
-            'exact_match', 'related_match',
-            'close_match', 'legacy_id',
-            'creator', 'contributor',
-            'date_created', 'date_modified',
-            'created_by',
-        )
+        exclude = ["lft", "rght", "tree_id", "level"]


### PR DESCRIPTION
This PR addresses issue #24 
Now `created_by` field (in skosconceptscheme, skoscollection and skosconcept) takes a string containing a username, e.g. when creating a concept:

```
{
    "pref_label": "Test concept",
    "pref_label_lang": "en",
    "scheme": 14,      # concept scheme database id because it's the only unique identifier
    "broader_concept": 684,    # broader concept database id because it's the only unique identifier
    "created_by": "admin"   # username
 }
```